### PR TITLE
Fixes some exploits that can be abused by modified clients.

### DIFF
--- a/common/src/main/java/me/drex/antixray/mixin/ServerPlayerGameModeMixin.java
+++ b/common/src/main/java/me/drex/antixray/mixin/ServerPlayerGameModeMixin.java
@@ -19,7 +19,11 @@ public abstract class ServerPlayerGameModeMixin {
 
     @Inject(
             method = "handleBlockBreakAction",
-            at = @At("TAIL")
+            at = @At(
+                    value = "FIELD",
+                    target = "Lnet/minecraft/server/level/ServerPlayerGameMode;lastSentState:I",
+                    ordinal = 0
+            )
     )
     public void onPlayerBreakBlock(BlockPos blockPos, ServerboundPlayerActionPacket.Action action, Direction direction, int i, int j, CallbackInfo ci) {
         Util.getBlockController(this.level).onPlayerLeftClickBlock((ServerPlayerGameMode) (Object) this, blockPos, action, direction, i);


### PR DESCRIPTION
## Changes
Only send block updates when starting to break a block (should keep intended behavior of updating earlier for those with higher ping). Note: fully breaking a block will still always update the blocks around it.

Prevents an exploit where the client can reveal obfuscated blocks by sending block break packets way outside of the range they can actually break blocks at.
##
Might obviously still be worth testing with a bit more than 1 player, but I doubt it will change anything for normal players.