### PR TITLE
Add: Bypass permission.

### DIFF
--- a/common/src/main/java/me/drex/antixray/AntiXray.java
+++ b/common/src/main/java/me/drex/antixray/AntiXray.java
@@ -25,5 +25,5 @@ public abstract class AntiXray {
 
     public abstract String getConfigFileName();
 
-    public abstract boolean canBypassXray(ServerPlayer player);
+    public abstract boolean hasBypassPermission(ServerPlayer player);
 }

--- a/common/src/main/java/me/drex/antixray/AntiXray.java
+++ b/common/src/main/java/me/drex/antixray/AntiXray.java
@@ -2,6 +2,7 @@ package me.drex.antixray;
 
 import me.drex.antixray.config.Config;
 import me.drex.antixray.util.Platform;
+import net.minecraft.server.level.ServerPlayer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -24,4 +25,5 @@ public abstract class AntiXray {
 
     public abstract String getConfigFileName();
 
+    public abstract boolean canBypassXray(ServerPlayer player);
 }

--- a/common/src/main/java/me/drex/antixray/config/Config.java
+++ b/common/src/main/java/me/drex/antixray/config/Config.java
@@ -3,7 +3,6 @@ package me.drex.antixray.config;
 import com.moandjiezana.toml.Toml;
 import me.drex.antixray.AntiXray;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/common/src/main/java/me/drex/antixray/config/WorldConfig.java
+++ b/common/src/main/java/me/drex/antixray/config/WorldConfig.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Executor;
 
 public class WorldConfig {
     public boolean enabled = false;
+    public boolean usePermission = false;
     public EngineMode engineMode = EngineMode.HIDE;
     public int maxBlockHeight = 64;
     public int updateRadius = 2;
@@ -47,6 +48,7 @@ public class WorldConfig {
     private void loadValues(Toml toml) {
         if (toml == null) return;
         if (toml.contains("enabled")) this.enabled = toml.getBoolean("enabled");
+        if (toml.contains("usePermission")) this.usePermission = toml.getBoolean("usePermission");
         if (toml.contains("engineMode")) {
             EngineMode mode = EngineMode.getById(Math.toIntExact(toml.getLong("engineMode")));
             if (mode != null) {
@@ -102,11 +104,11 @@ public class WorldConfig {
         if (!this.enabled) return DisabledChunkPacketBlockController.NO_OPERATION_INSTANCE;
         return switch (engineMode) {
             case HIDE ->
-                    new HideChunkPacketBlockController(level, executor, hiddenBlocks, maxBlockHeight, updateRadius, lavaObscures);
+                    new HideChunkPacketBlockController(level, executor, hiddenBlocks, maxBlockHeight, updateRadius, lavaObscures, usePermission);
             case OBFUSCATE ->
-                    new ObfuscateChunkPacketBlockController(level, executor, replacementBlocks, hiddenBlocks, maxBlockHeight, updateRadius, lavaObscures);
+                    new ObfuscateChunkPacketBlockController(level, executor, replacementBlocks, hiddenBlocks, maxBlockHeight, updateRadius, lavaObscures, usePermission);
             case OBFUSCATE_LAYER ->
-                    new ObfuscateLayerChunkPacketBlockController(level, executor, replacementBlocks, hiddenBlocks, maxBlockHeight, updateRadius, lavaObscures);
+                    new ObfuscateLayerChunkPacketBlockController(level, executor, replacementBlocks, hiddenBlocks, maxBlockHeight, updateRadius, lavaObscures, usePermission);
         };
     }
 

--- a/common/src/main/java/me/drex/antixray/interfaces/IChunkPacket.java
+++ b/common/src/main/java/me/drex/antixray/interfaces/IChunkPacket.java
@@ -1,8 +1,13 @@
 package me.drex.antixray.interfaces;
 
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.chunk.LevelChunk;
+
 public interface IChunkPacket {
 
     boolean isReady();
 
     void setReady(boolean ready);
+
+    void modifyPacket(LevelChunk chunk, ServerPlayer player);
 }

--- a/common/src/main/java/me/drex/antixray/mixin/ChunkSerializerMixin.java
+++ b/common/src/main/java/me/drex/antixray/mixin/ChunkSerializerMixin.java
@@ -6,7 +6,6 @@ import me.drex.antixray.interfaces.IPalettedContainer;
 import me.drex.antixray.util.Util;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
-import net.minecraft.core.SectionPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.server.level.ServerLevel;

--- a/common/src/main/java/me/drex/antixray/mixin/ClientboundLevelChunkWithLightPacketMixin.java
+++ b/common/src/main/java/me/drex/antixray/mixin/ClientboundLevelChunkWithLightPacketMixin.java
@@ -7,18 +7,13 @@ import me.drex.antixray.util.Util;
 import me.drex.antixray.util.controller.ChunkPacketBlockController;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.LevelChunk;
-import net.minecraft.world.level.lighting.LevelLightEngine;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import java.util.BitSet;
 
 @Mixin(ClientboundLevelChunkWithLightPacket.class)
 public abstract class ClientboundLevelChunkWithLightPacketMixin implements IChunkPacket {
@@ -29,14 +24,12 @@ public abstract class ClientboundLevelChunkWithLightPacketMixin implements IChun
     @Final
     private ClientboundLevelChunkPacketData chunkData;
 
-    @Inject(
-            method = "<init>(Lnet/minecraft/world/level/chunk/LevelChunk;Lnet/minecraft/world/level/lighting/LevelLightEngine;Ljava/util/BitSet;Ljava/util/BitSet;)V",
-            at = @At("TAIL")
-    )
-    private void onInit(LevelChunk chunk, LevelLightEngine levelLightEngine, BitSet bitSet, BitSet bitSet2, CallbackInfo ci) {
+    @Override
+    public void modifyPacket(LevelChunk chunk, ServerPlayer player) {
         final ClientboundLevelChunkWithLightPacket packet = (ClientboundLevelChunkWithLightPacket) (Object) this;
-        final ChunkPacketBlockController controller = Util.getBlockController(chunk.getLevel());
+        final ChunkPacketBlockController controller = Util.getBlockController(player);
         final ChunkPacketInfo<BlockState> packetInfo = controller.getChunkPacketInfo(packet, chunk);
+
         ((IChunkPacketData) this.chunkData).customExtractChunkData(packetInfo);
         controller.modifyBlocks(packet, packetInfo);
     }

--- a/common/src/main/java/me/drex/antixray/mixin/PlayerChunkSenderMixin.java
+++ b/common/src/main/java/me/drex/antixray/mixin/PlayerChunkSenderMixin.java
@@ -1,0 +1,31 @@
+package me.drex.antixray.mixin;
+
+import me.drex.antixray.interfaces.IChunkPacket;
+import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.network.PlayerChunkSender;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.lighting.LevelLightEngine;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.BitSet;
+
+@Mixin(PlayerChunkSender.class)
+public class PlayerChunkSenderMixin {
+
+    @Redirect(
+            method = "sendChunk",
+            at = @At(
+                    value = "NEW",
+                    target = "(Lnet/minecraft/world/level/chunk/LevelChunk;Lnet/minecraft/world/level/lighting/LevelLightEngine;Ljava/util/BitSet;Ljava/util/BitSet;)Lnet/minecraft/network/protocol/game/ClientboundLevelChunkWithLightPacket;"
+            )
+    )
+    private static ClientboundLevelChunkWithLightPacket modifyChunkPacket(LevelChunk chunk, LevelLightEngine lightEngine, BitSet bitSet, BitSet bitSet2, ServerGamePacketListenerImpl listener, ServerLevel level, LevelChunk levelChunk) {
+        ClientboundLevelChunkWithLightPacket packet = new ClientboundLevelChunkWithLightPacket(chunk, lightEngine, bitSet, bitSet2);
+        ((IChunkPacket) packet).modifyPacket(levelChunk, listener.player);
+        return packet;
+    }
+}

--- a/common/src/main/java/me/drex/antixray/util/Util.java
+++ b/common/src/main/java/me/drex/antixray/util/Util.java
@@ -2,6 +2,8 @@ package me.drex.antixray.util;
 
 import me.drex.antixray.interfaces.ILevel;
 import me.drex.antixray.util.controller.ChunkPacketBlockController;
+import me.drex.antixray.util.controller.DisabledChunkPacketBlockController;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelHeightAccessor;
 import net.minecraft.world.level.chunk.ChunkAccess;
@@ -11,6 +13,11 @@ public final class Util {
 
     public static ChunkPacketBlockController getBlockController(Level level) {
         return ((ILevel) level).getChunkPacketBlockController();
+    }
+
+    public static ChunkPacketBlockController getBlockController(ServerPlayer player) {
+        ChunkPacketBlockController controller = getBlockController(player.level());
+        return controller.shouldModify(player) ? controller : DisabledChunkPacketBlockController.NO_OPERATION_INSTANCE;
     }
 
     // Converts height accessors from ChunkAccess into levels.

--- a/common/src/main/java/me/drex/antixray/util/controller/ChunkPacketBlockController.java
+++ b/common/src/main/java/me/drex/antixray/util/controller/ChunkPacketBlockController.java
@@ -5,6 +5,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
 import net.minecraft.network.protocol.game.ServerboundPlayerActionPacket;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.level.ServerPlayerGameMode;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
@@ -22,4 +23,5 @@ public interface ChunkPacketBlockController {
 
     void onPlayerLeftClickBlock(ServerPlayerGameMode serverPlayerGameMode, BlockPos blockPos, ServerboundPlayerActionPacket.Action action, Direction direction, int worldHeight);
 
+    boolean shouldModify(ServerPlayer player);
 }

--- a/common/src/main/java/me/drex/antixray/util/controller/ChunkPacketBlockControllerAntiXray.java
+++ b/common/src/main/java/me/drex/antixray/util/controller/ChunkPacketBlockControllerAntiXray.java
@@ -72,10 +72,7 @@ public abstract class ChunkPacketBlockControllerAntiXray implements ChunkPacketB
 
     @Override
     public boolean shouldModify(ServerPlayer player) {
-        if (this.usePermission && player.hasPermissions(2)) {
-            return false;
-        }
-        return !AntiXray.INSTANCE.canBypassXray(player);
+        return !this.usePermission || (!player.hasPermissions(2) && !AntiXray.INSTANCE.hasBypassPermission(player));
     }
 
     @Override

--- a/common/src/main/java/me/drex/antixray/util/controller/DisabledChunkPacketBlockController.java
+++ b/common/src/main/java/me/drex/antixray/util/controller/DisabledChunkPacketBlockController.java
@@ -6,6 +6,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
 import net.minecraft.network.protocol.game.ServerboundPlayerActionPacket;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.level.ServerPlayerGameMode;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
@@ -16,6 +17,11 @@ public class DisabledChunkPacketBlockController implements ChunkPacketBlockContr
     public static final DisabledChunkPacketBlockController NO_OPERATION_INSTANCE = new DisabledChunkPacketBlockController();
 
     private DisabledChunkPacketBlockController() {
+    }
+
+    @Override
+    public boolean shouldModify(ServerPlayer player) {
+        return false;
     }
 
     @Override

--- a/common/src/main/java/me/drex/antixray/util/controller/HideChunkPacketBlockController.java
+++ b/common/src/main/java/me/drex/antixray/util/controller/HideChunkPacketBlockController.java
@@ -20,8 +20,8 @@ public class HideChunkPacketBlockController extends ChunkPacketBlockControllerAn
     private final int[] presetBlockStateBitsNetherrackGlobal;
     private final int[] presetBlockStateBitsEndStoneGlobal;
 
-    public HideChunkPacketBlockController(Level level, Executor executor, Set<Block> toObfuscate, int maxBlockHeight, int updateRadius, boolean lavaObscures) {
-        super(level, executor, toObfuscate, maxBlockHeight, updateRadius, lavaObscures);
+    public HideChunkPacketBlockController(Level level, Executor executor, Set<Block> toObfuscate, int maxBlockHeight, int updateRadius, boolean lavaObscures, boolean usePermission) {
+        super(level, executor, toObfuscate, maxBlockHeight, updateRadius, lavaObscures, usePermission);
         presetBlockStatesStone = new BlockState[]{Blocks.STONE.defaultBlockState()};
         presetBlockStatesDeepslate = new BlockState[]{Blocks.DEEPSLATE.defaultBlockState()};
         presetBlockStatesNetherrack = new BlockState[]{Blocks.NETHERRACK.defaultBlockState()};

--- a/common/src/main/java/me/drex/antixray/util/controller/ObfuscateChunkPacketBlockController.java
+++ b/common/src/main/java/me/drex/antixray/util/controller/ObfuscateChunkPacketBlockController.java
@@ -17,8 +17,8 @@ public class ObfuscateChunkPacketBlockController extends ChunkPacketBlockControl
     private final BlockState[] presetBlockStates;
     private final int[] presetBlockStateBitsGlobal;
 
-    public ObfuscateChunkPacketBlockController(Level level, Executor executor, Set<Block> replacementBlocks, Set<Block> hiddenBlocks, int maxBlockHeight, int updateRadius, boolean lavaObscures) {
-        super(level, executor, Stream.concat(replacementBlocks.stream(), hiddenBlocks.stream()).collect(Collectors.toSet()), maxBlockHeight, updateRadius, lavaObscures);
+    public ObfuscateChunkPacketBlockController(Level level, Executor executor, Set<Block> replacementBlocks, Set<Block> hiddenBlocks, int maxBlockHeight, int updateRadius, boolean lavaObscures, boolean usePermission) {
+        super(level, executor, Stream.concat(replacementBlocks.stream(), hiddenBlocks.stream()).collect(Collectors.toSet()), maxBlockHeight, updateRadius, lavaObscures, usePermission);
 
         Set<BlockState> presetBlockStateSet = new LinkedHashSet<>();
         for (Block block : hiddenBlocks) {

--- a/common/src/main/java/me/drex/antixray/util/controller/ObfuscateLayerChunkPacketBlockController.java
+++ b/common/src/main/java/me/drex/antixray/util/controller/ObfuscateLayerChunkPacketBlockController.java
@@ -9,8 +9,8 @@ import java.util.function.IntSupplier;
 
 public class ObfuscateLayerChunkPacketBlockController extends ObfuscateChunkPacketBlockController {
 
-    public ObfuscateLayerChunkPacketBlockController(Level level, Executor executor, Set<Block> replacementBlocks, Set<Block> hiddenBlocks, int maxBlockHeight, int updateRadius, boolean lavaObscures) {
-        super(level, executor, replacementBlocks, hiddenBlocks, maxBlockHeight, updateRadius, lavaObscures);
+    public ObfuscateLayerChunkPacketBlockController(Level level, Executor executor, Set<Block> replacementBlocks, Set<Block> hiddenBlocks, int maxBlockHeight, int updateRadius, boolean lavaObscures, boolean usePermission) {
+        super(level, executor, replacementBlocks, hiddenBlocks, maxBlockHeight, updateRadius, lavaObscures, usePermission);
     }
 
     @Override

--- a/common/src/main/resources/data/antixray-fabric.toml
+++ b/common/src/main/resources/data/antixray-fabric.toml
@@ -2,6 +2,7 @@
 
 # Default values
 enabled = false
+usePermission = false
 
 # World specific values
 [overworld]

--- a/common/src/main/resources/data/antixray-forge.toml
+++ b/common/src/main/resources/data/antixray-forge.toml
@@ -2,6 +2,7 @@
 
 # Default values
 enabled = false
+usePermission = false
 
 # World specific values
 [overworld]

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
     implementation project(":common")
     include("com.moandjiezana.toml:toml4j:${rootProject.toml_version}")
+    include(modImplementation("me.lucko:fabric-permissions-api:${project.fabric_permission_api_version}"))
 }
 
 loom {

--- a/fabric/src/main/java/me/drex/antixray/fabric/AntiXrayFabric.java
+++ b/fabric/src/main/java/me/drex/antixray/fabric/AntiXrayFabric.java
@@ -2,7 +2,9 @@ package me.drex.antixray.fabric;
 
 import me.drex.antixray.AntiXray;
 import me.drex.antixray.util.Platform;
+import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.server.level.ServerPlayer;
 
 import java.nio.file.Path;
 
@@ -20,5 +22,10 @@ public class AntiXrayFabric extends AntiXray {
     @Override
     public String getConfigFileName() {
         return "antixray-fabric.toml";
+    }
+
+    @Override
+    public boolean canBypassXray(ServerPlayer player) {
+        return Permissions.check(player, "antixray.bypass");
     }
 }

--- a/fabric/src/main/java/me/drex/antixray/fabric/AntiXrayFabric.java
+++ b/fabric/src/main/java/me/drex/antixray/fabric/AntiXrayFabric.java
@@ -25,7 +25,7 @@ public class AntiXrayFabric extends AntiXray {
     }
 
     @Override
-    public boolean canBypassXray(ServerPlayer player) {
+    public boolean hasBypassPermission(ServerPlayer player) {
         return Permissions.check(player, "antixray.bypass");
     }
 }

--- a/fabric/src/main/resources/antixray.mixins.json
+++ b/fabric/src/main/resources/antixray.mixins.json
@@ -11,6 +11,7 @@
     "LevelChunkSectionMixin",
     "LevelMixin",
     "PalettedContainerMixin",
+    "PlayerChunkSenderMixin",
     "ServerLevelMixin",
     "ServerPlayerGameModeMixin"
   ],

--- a/forge/src/main/java/me/drex/antixray/forge/AntiXrayForge.java
+++ b/forge/src/main/java/me/drex/antixray/forge/AntiXrayForge.java
@@ -32,7 +32,7 @@ public class AntiXrayForge extends AntiXray {
     }
 
     @Override
-    public boolean canBypassXray(ServerPlayer player) {
+    public boolean hasBypassPermission(ServerPlayer player) {
         return PermissionAPI.getPermission(player, ANTIXRAY_BYPASS);
     }
 

--- a/forge/src/main/java/me/drex/antixray/forge/AntiXrayForge.java
+++ b/forge/src/main/java/me/drex/antixray/forge/AntiXrayForge.java
@@ -2,14 +2,23 @@ package me.drex.antixray.forge;
 
 import me.drex.antixray.AntiXray;
 import me.drex.antixray.util.Platform;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.loading.FMLPaths;
+import net.minecraftforge.server.permission.PermissionAPI;
+import net.minecraftforge.server.permission.events.PermissionGatherEvent;
+import net.minecraftforge.server.permission.nodes.PermissionNode;
+import net.minecraftforge.server.permission.nodes.PermissionTypes;
 
 import java.nio.file.Path;
 
 public class AntiXrayForge extends AntiXray {
+    public static final PermissionNode<Boolean> ANTIXRAY_BYPASS = new PermissionNode<>(MOD_ID, "bypass", PermissionTypes.BOOLEAN, (player, playerUUID, context) -> false);
 
     public AntiXrayForge() {
         super(Platform.FORGE);
+        MinecraftForge.EVENT_BUS.register(this);
     }
 
     @Override
@@ -20,5 +29,15 @@ public class AntiXrayForge extends AntiXray {
     @Override
     public String getConfigFileName() {
         return "antixray-forge.toml";
+    }
+
+    @Override
+    public boolean canBypassXray(ServerPlayer player) {
+        return PermissionAPI.getPermission(player, ANTIXRAY_BYPASS);
+    }
+
+    @SubscribeEvent
+    public void handlePermissionNodesGather(PermissionGatherEvent.Nodes event) {
+        event.addNodes(ANTIXRAY_BYPASS);
     }
 }

--- a/forge/src/main/resources/antixray.mixins.json
+++ b/forge/src/main/resources/antixray.mixins.json
@@ -11,6 +11,7 @@
     "LevelChunkSectionMixin",
     "LevelMixin",
     "PalettedContainerMixin",
+    "PlayerChunkSenderMixin",
     "ServerLevelMixin",
     "ServerPlayerGameModeMixin"
   ],

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,4 @@ mod_name=AntiXray
 forge_version=48.0.6
 fabric_loader_version=0.14.22
 toml_version=0.7.2
+fabric_permission_api_version=0.2-SNAPSHOT


### PR DESCRIPTION
Also adds `usePermission` config entry to enable this permission (default = false)

Note: this currently breaks if another mod creates and sends its own level chunk packets in their own methods where we can't modify the packet.