### PR TITLE
Fix compatibility with ServerReplay

### DIFF
--- a/common/src/main/java/me/drex/antixray/common/mixin/ClientboundLevelChunkWithLightPacketMixin.java
+++ b/common/src/main/java/me/drex/antixray/common/mixin/ClientboundLevelChunkWithLightPacketMixin.java
@@ -10,6 +10,7 @@ import me.drex.antixray.common.util.Arguments;
 import me.drex.antixray.common.util.ChunkPacketInfo;
 import me.drex.antixray.common.util.Util;
 import me.drex.antixray.common.util.controller.ChunkPacketBlockController;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
 import net.minecraft.world.level.block.state.BlockState;
@@ -79,6 +80,14 @@ public abstract class ClientboundLevelChunkWithLightPacketMixin implements IChun
         @Share("chunkPacketInfo") LocalRef<ChunkPacketInfo<BlockState>> chunkPacketInfoLocalRef
     ) {
         controllerLocalRef.get().modifyBlocks((ClientboundLevelChunkWithLightPacket) (Object) this, chunkPacketInfoLocalRef.get());
+    }
+
+    @Inject(
+        method = "<init>(Lnet/minecraft/network/RegistryFriendlyByteBuf;)V",
+        at = @At("TAIL")
+    )
+    public void markReady(RegistryFriendlyByteBuf registryFriendlyByteBuf, CallbackInfo ci) {
+        this.antixray$ready = true;
     }
 
     @Override


### PR DESCRIPTION
This PR fixes a compatibility issue with [ServerReplay](https://github.com/senseiwells/ServerReplay)'s server-side replay viewer. The viewer reads in packets from disk and sends them to the client. AntiXray prevents any chunk packets from being sent until they are marked as ready, however, these packets will only ever be marked as ready if the packet was constructed using `ClientboundLevelChunkWithLightPacket(LevelChunk, LevelLightEngine, BitSet, BitSet)`. When decoding packets the other constructor `ClientboundLevelChunkWithLightPacket(RegistryFriendlyByteBuf)` is called, thus the packet is never marked ready blocking all subsequent packets from being sent to the client.

This PR resolves this by just marking all packets that are decoded ready.

It may also be worth noting that during my testing this assertion was triggered:
https://github.com/DrexHD/AntiXray/blob/b8ab64956bf1c0fec03e7f8502ec5edbefbdc32a/common/src/main/java/me/drex/antixray/common/mixin/ConnectionMixin.java#L37-L48
ServerReplay's replay viewer sends all packets off the main thread, so you may have a potential race condition here, the potential solution to this is by synchronizing on `pendingActions` when adding to both `pendingActions` and `antiXray$isActionReady`.