### PR TITLE
Fixed null packet info issue

### DIFF
--- a/common/src/main/java/me/drex/antixray/common/mixin/ClientboundLevelChunkPacketDataMixin.java
+++ b/common/src/main/java/me/drex/antixray/common/mixin/ClientboundLevelChunkPacketDataMixin.java
@@ -34,7 +34,9 @@ public abstract class ClientboundLevelChunkPacketDataMixin {
     private void setChunkPacketInfoBuffer(LevelChunk levelChunk, CallbackInfo ci) {
         if (Arguments.PACKET_INFO.isBound()) {
             ChunkPacketInfo<BlockState> chunkPacketInfo = Arguments.PACKET_INFO.get();
-            chunkPacketInfo.setBuffer(this.buffer);
+            if (chunkPacketInfo != null) {
+                chunkPacketInfo.setBuffer(this.buffer);
+            }
         }
     }
 


### PR DESCRIPTION
This commit solves #80 
This used to be in the code before the 26.1 patch and was removed by https://github.com/DrexHD/AntiXray/commit/1a3229ab2d1aefde302a130b98d5b3b7f023cccd 

Since `Arguments.PACKET_INFO.isBound()` can pass if `chunkPacketInfo == null` which is the cause of the error when entering the end dimension. 