### PR TITLE
fix crash with fastnoise

### DIFF
--- a/common/src/main/java/me/drex/antixray/common/mixin/PalettedContainerMixin.java
+++ b/common/src/main/java/me/drex/antixray/common/mixin/PalettedContainerMixin.java
@@ -69,6 +69,8 @@ public abstract class PalettedContainerMixin<T> {
     )
     private void addPresetValuesWithEntries(Strategy<T> strategy, Configuration configuration, BitStorage bitStorage, Palette<T> palette, CallbackInfo ci) {
         antiXray$initializePresetValues();
+        
+        if (!Arguments.PALETTE_ENTRIES.isBound()) return;
         //noinspection unchecked
         List<T> paletteEntries = (List<T>) Arguments.PALETTE_ENTRIES.get();
 


### PR DESCRIPTION
Hi, developer of fastnoise

I use the constructor outside paletted container, causing a crash b/c of unbound scoped value.